### PR TITLE
Add `angle` to TextArea to control text rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "glyphon"
+name = "avenger-glyphon"
 description = "Fast, simple 2D text rendering for wgpu"
 version = "0.3.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This is a (hopefully short-term) fork of the excellent glyphon project which adds text rotation support.
+The approach here is used by the Avenger visualization project, but is not sufficiently general as to be
+included in glyphon itself. See discussion in https://github.com/grovesNL/glyphon/pull/64 for background.
+
+---
 <h1 align="center">
   🦅 glyphon 🦁
 </h1>

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -113,6 +113,7 @@ async fn run() {
                                 bottom: 160,
                             },
                             default_color: Color::rgb(255, 255, 255),
+                            angle: 0.0,
                         }],
                         &mut cache,
                     )

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,4 +1,4 @@
-use glyphon::{
+use avenger_glyphon::{
     Attrs, Buffer, Color, Family, FontSystem, Metrics, Resolution, Shaping, SwashCache, TextArea,
     TextAtlas, TextBounds, TextRenderer,
 };
@@ -103,17 +103,18 @@ async fn run() {
                         },
                         [TextArea {
                             buffer: &buffer,
-                            left: 10.0,
-                            top: 10.0,
+                            left: 200.0,
+                            top: 200.0,
                             scale: 1.0,
                             bounds: TextBounds {
                                 left: 0,
                                 top: 0,
                                 right: 600,
-                                bottom: 160,
+                                bottom: 360,
                             },
                             default_color: Color::rgb(255, 255, 255),
-                            angle: 0.0,
+                            angle: -30.0,
+                            rotation_origin: Some([200.0, 200.0]),
                         }],
                         &mut cache,
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub(crate) struct GlyphToRender {
     content_type: u32,
     depth: f32,
     angle: f32,
+    rotation_origin: [f32; 2],
 }
 
 /// The screen resolution to use when rendering text.
@@ -114,5 +115,7 @@ pub struct TextArea<'a> {
     // The default color of the text area.
     pub default_color: Color,
     /// Rotation angle in degrees
-    pub angle: f32
+    pub angle: f32,
+    /// Point to rotate text around. Defaults to top left
+    pub rotation_origin: Option<[f32; 2]>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) struct GlyphToRender {
     color: u32,
     content_type: u32,
     depth: f32,
+    angle: f32,
 }
 
 /// The screen resolution to use when rendering text.
@@ -112,4 +113,6 @@ pub struct TextArea<'a> {
     pub bounds: TextBounds,
     // The default color of the text area.
     pub default_color: Color,
+    /// Rotation angle in degrees
+    pub angle: f32
 }

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -7,6 +7,7 @@ struct VertexInput {
     @location(4) content_type: u32,
     @location(5) depth: f32,
     @location(6) angle: f32,
+    @location(7) rotation_origin: vec2<f32>,
 }
 
 struct VertexOutput {
@@ -64,9 +65,10 @@ fn vs_main(in_vert: VertexInput) -> VertexOutput {
 
     var vert_output: VertexOutput;
 
-    let angle_rad = PI * in_vert.angle / 180.0;
+    let angle_rad = -PI * in_vert.angle / 180.0;
     let rot = mat2x2(cos(angle_rad), -sin(angle_rad), sin(angle_rad), cos(angle_rad));
-    let rot_pos = rot * vec2<f32>(pos);
+    let rot_pos = rot * vec2<f32>( vec2<f32>(pos) - in_vert.rotation_origin) + in_vert.rotation_origin;
+
     vert_output.position = vec4<f32>(
         2.0 * vec2<f32>(rot_pos) / vec2<f32>(params.screen_resolution) - 1.0,
         in_vert.depth,

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -6,6 +6,7 @@ struct VertexInput {
     @location(3) color: u32,
     @location(4) content_type: u32,
     @location(5) depth: f32,
+    @location(6) angle: f32,
 }
 
 struct VertexOutput {
@@ -31,6 +32,8 @@ var mask_atlas_texture: texture_2d<f32>;
 
 @group(0) @binding(3)
 var atlas_sampler: sampler;
+
+const PI = 3.14159265359;
 
 @vertex
 fn vs_main(in_vert: VertexInput) -> VertexOutput {
@@ -61,8 +64,11 @@ fn vs_main(in_vert: VertexInput) -> VertexOutput {
 
     var vert_output: VertexOutput;
 
+    let angle_rad = PI * in_vert.angle / 180.0;
+    let rot = mat2x2(cos(angle_rad), -sin(angle_rad), sin(angle_rad), cos(angle_rad));
+    let rot_pos = rot * vec2<f32>(pos);
     vert_output.position = vec4<f32>(
-        2.0 * vec2<f32>(pos) / vec2<f32>(params.screen_resolution) - 1.0,
+        2.0 * vec2<f32>(rot_pos) / vec2<f32>(params.screen_resolution) - 1.0,
         in_vert.depth,
         1.0,
     );

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -346,6 +346,12 @@ impl TextAtlas {
                     offset: size_of::<u32>() as u64 * 7,
                     shader_location: 6,
                 },
+                // rotation_origin
+                wgpu::VertexAttribute {
+                    format: VertexFormat::Float32x2,
+                    offset: size_of::<u32>() as u64 * 8,
+                    shader_location: 7,
+                },
             ],
         }];
 

--- a/src/text_atlas.rs
+++ b/src/text_atlas.rs
@@ -286,9 +286,9 @@ impl TextAtlas {
     ) -> Self {
         let sampler = device.create_sampler(&SamplerDescriptor {
             label: Some("glyphon sampler"),
-            min_filter: FilterMode::Nearest,
-            mag_filter: FilterMode::Nearest,
-            mipmap_filter: FilterMode::Nearest,
+            min_filter: FilterMode::Linear,
+            mag_filter: FilterMode::Linear,
+            mipmap_filter: FilterMode::Linear,
             lod_min_clamp: 0f32,
             lod_max_clamp: 0f32,
             ..Default::default()
@@ -304,35 +304,47 @@ impl TextAtlas {
             array_stride: size_of::<GlyphToRender>() as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[
+                // pos
                 wgpu::VertexAttribute {
                     format: VertexFormat::Sint32x2,
                     offset: 0,
                     shader_location: 0,
                 },
+                // dim
                 wgpu::VertexAttribute {
                     format: VertexFormat::Uint32,
                     offset: size_of::<u32>() as u64 * 2,
                     shader_location: 1,
                 },
+                // uv
                 wgpu::VertexAttribute {
                     format: VertexFormat::Uint32,
                     offset: size_of::<u32>() as u64 * 3,
                     shader_location: 2,
                 },
+                // color
                 wgpu::VertexAttribute {
                     format: VertexFormat::Uint32,
                     offset: size_of::<u32>() as u64 * 4,
                     shader_location: 3,
                 },
+                // content_type
                 wgpu::VertexAttribute {
                     format: VertexFormat::Uint32,
                     offset: size_of::<u32>() as u64 * 5,
                     shader_location: 4,
                 },
+                // depth
                 wgpu::VertexAttribute {
                     format: VertexFormat::Float32,
                     offset: size_of::<u32>() as u64 * 6,
                     shader_location: 5,
+                },
+                // angle
+                wgpu::VertexAttribute {
+                    format: VertexFormat::Float32,
+                    offset: size_of::<u32>() as u64 * 7,
+                    shader_location: 6,
                 },
             ],
         }];

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -134,7 +134,9 @@ impl TextRenderer {
 
                             // Find a position in the packer
                             let allocation = loop {
-                                match inner.try_allocate(width, height) {
+                                // Add 1-pixel buffer to avoid linear interpolation artifacts
+                                // with rotated text
+                                match inner.try_allocate(width + 1, height + 1) {
                                     Some(a) => break a,
                                     None => {
                                         if !atlas.grow(
@@ -278,6 +280,7 @@ impl TextRenderer {
                             color: color.0,
                             content_type: content_type as u32,
                             depth,
+                            angle: text_area.angle,
                         })
                         .take(4),
                     );

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -281,6 +281,7 @@ impl TextRenderer {
                             content_type: content_type as u32,
                             depth,
                             angle: text_area.angle,
+                            rotation_origin: text_area.rotation_origin.unwrap_or([text_area.top, text_area.left])
                         })
                         .take(4),
                     );

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -225,44 +225,47 @@ impl TextRenderer {
                     let bounds_max_x = text_area.bounds.right.min(screen_resolution.width as i32);
                     let bounds_max_y = text_area.bounds.bottom.min(screen_resolution.height as i32);
 
-                    // Starts beyond right edge or ends beyond left edge
-                    let max_x = x + width;
-                    if x > bounds_max_x || max_x < bounds_min_x {
-                        continue;
-                    }
+                    // Only clip un-rotated text for now
+                    if text_area.angle == 0.0 {
+                        // Starts beyond right edge or ends beyond left edge
+                        let max_x = x + width;
+                        if x > bounds_max_x || max_x < bounds_min_x {
+                            continue;
+                        }
 
-                    // Starts beyond bottom edge or ends beyond top edge
-                    let max_y = y + height;
-                    if y > bounds_max_y || max_y < bounds_min_y {
-                        continue;
-                    }
+                        // Starts beyond bottom edge or ends beyond top edge
+                        let max_y = y + height;
+                        if y > bounds_max_y || max_y < bounds_min_y {
+                            continue;
+                        }
 
-                    // Clip left ege
-                    if x < bounds_min_x {
-                        let right_shift = bounds_min_x - x;
+                        // Clip left ege
+                        if x < bounds_min_x {
+                            let right_shift = bounds_min_x - x;
 
-                        x = bounds_min_x;
-                        width = max_x - bounds_min_x;
-                        atlas_x += right_shift as u16;
-                    }
+                            x = bounds_min_x;
+                            width = max_x - bounds_min_x;
+                            atlas_x += right_shift as u16;
+                        }
 
-                    // Clip right edge
-                    if x + width > bounds_max_x {
-                        width = bounds_max_x - x;
-                    }
+                        // Clip right edge
+                        if x + width > bounds_max_x {
+                            width = bounds_max_x - x;
+                        }
 
-                    // Clip top edge
-                    if y < bounds_min_y {
-                        let bottom_shift = bounds_min_y - y;
+                        // Clip top edge
+                        if y < bounds_min_y {
+                            let bottom_shift = bounds_min_y - y;
 
-                        y = bounds_min_y;
-                        height = max_y - bounds_min_y;
-                        atlas_y += bottom_shift as u16;
-                    }
+                            y = bounds_min_y;
+                            height = max_y - bounds_min_y;
+                            atlas_y += bottom_shift as u16;
+                        }
 
-                    // Clip bottom edge
-                    if y + height > bounds_max_y {
-                        height = bounds_max_y - y;
+                        // Clip bottom edge
+                        if y + height > bounds_max_y {
+                            height = bounds_max_y - y;
+                        }
                     }
 
                     let color = match glyph.color_opt {

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -281,7 +281,7 @@ impl TextRenderer {
                             content_type: content_type as u32,
                             depth,
                             angle: text_area.angle,
-                            rotation_origin: text_area.rotation_origin.unwrap_or([text_area.top, text_area.left])
+                            rotation_origin: text_area.rotation_origin.unwrap_or([text_area.left, text_area.top])
                         })
                         .take(4),
                     );


### PR DESCRIPTION
This PR adds an `angle: f32` property to `TextArea` to control the rotation of the text in text area. This angle is routed through to `GlyphToRender` and to the shader where it's used to construct a 2d rotation matrix which is applied to the vertex positions.

To make the text look smooth when rotated, the sampler mode was changed from `FilterMode::Nearest` to `FilterMode::Linear`.

When text is rotated, linear interpolation can cause artifacts on glyph borders due to interpolation against neighboring glyphs in the texture atlas. To fix this, a one pixel buffer was added to the glyph width and height when positioning the glyph in the text atlas.